### PR TITLE
Preserve post URL and support reels

### DIFF
--- a/Facebook Scraper.js
+++ b/Facebook Scraper.js
@@ -356,6 +356,11 @@
 
   let POST_URL=location.href;
   function postKeyFromURL(u){ try{ const x=new URL(u); x.hash=''; return x.toString(); }catch(e){ return u; } }
+  function isPostURL(u){
+    try{
+      return /(permalink\.php|[?&](story_fbid|fbid)=|\/posts\/|\/photos\/|\/videos\/|\/reel\/|\/reels\/)/i.test(u);
+    }catch(e){ return false; }
+  }
   function setPostKeyLabel(){
     const postKeyEl=ui.querySelector('#fbp-postkey');
     const key=postKeyFromURL(POST_URL);
@@ -364,12 +369,20 @@
   }
   setPostKeyLabel();
   (function(){
-    function refreshPostKey(){ POST_URL = location.href; setPostKeyLabel(); }
+    function refreshPostKey(){
+      const dialogs = document.querySelectorAll('[role="dialog"]');
+      const top = dialogs[dialogs.length - 1];
+      const resolved = resolvePostURL(top);
+      if (isPostURL(resolved) && resolved !== POST_URL){
+        POST_URL = resolved;
+        setPostKeyLabel();
+      }
+    }
     const _push = history.pushState, _replace = history.replaceState;
     history.pushState = function(){ const r=_push.apply(this, arguments); refreshPostKey(); return r; };
     history.replaceState = function(){ const r=_replace.apply(this, arguments); refreshPostKey(); return r; };
     addEventListener('popstate', refreshPostKey);
-    let last = location.href; setInterval(()=>{ if(location.href!==last){ last=location.href; refreshPostKey(); } },1000);
+    setInterval(refreshPostKey,1000);
   })();
   ui.querySelector('#fbp-copyurl').addEventListener('click', async ()=>{
     try{ await navigator.clipboard.writeText(POST_URL); toast('Post URL copied'); }
@@ -466,8 +479,16 @@
       if(/\/posts\//i.test(h)) add(h);
       if(/\/videos\//i.test(h)) add(h);
       if(/\/photos\//i.test(h)) add(h);
+      if(/\/reel(s)?\//i.test(h)) add(h);
     });
-    const score = u => ( (/\/posts\//.test(u)?8:0) + (/(permalink\.php|story_fbid|fbid=)/.test(u)?8:0) + (/\/photos\//.test(u)?4:0) + (/\/videos\//.test(u)?4:0) - ((/[?&]v=/.test(u)&&/\/watch/.test(u))?2:0) );
+    const score = u => (
+      (/\/posts\//.test(u)?8:0) +
+      (/(permalink\.php|story_fbid|fbid=)/.test(u)?8:0) +
+      (/\/photos\//.test(u)?4:0) +
+      (/\/videos\//.test(u)?4:0) +
+      (/\/reel(s)?\//.test(u)?4:0) -
+      ((/[?&]v=/.test(u)&&/\/watch/.test(u))?2:0)
+    );
     let best=null, bestScore=-1; cand.forEach(u=>{ const s=score(u); if(s>bestScore){ best=u; bestScore=s; }});
     return best || location.href;
   }
@@ -635,7 +656,8 @@
     }
 
     const dlg = getDialog(sc);
-    POST_URL = resolvePostURL(dlg);
+    const maybeURL = resolvePostURL(dlg);
+    if (isPostURL(maybeURL)) POST_URL = maybeURL;
     setPostKeyLabel();
 
     const myToken = ++runToken;


### PR DESCRIPTION
## Summary
- keep last post URL unless a new post URL is detected
- detect reels and other post URLs when resolving the publication link
- use the detected post URL when starting a scrape
- refresh post URL when navigating within dialogs so the address stays in sync with opened content

## Testing
- `node --check 'Facebook Scraper.js'`


------
https://chatgpt.com/codex/tasks/task_b_68adc0312c8483298a0f97eeec22c43d