### PR TITLE
Allow runtime config and clarify usage

### DIFF
--- a/Facebook Scraper.js
+++ b/Facebook Scraper.js
@@ -7,12 +7,14 @@
   const sleep = ms => new Promise(r => setTimeout(r, ms));
   const now = ()=>performance.now();
 
+  const USER_CONFIG = window.FBP_CONFIG || {};
+
   // ===== Tuning knobs =====
-  const PAUSE = { likes: 1500, comments: 1700, shares: 1800 };
+  const PAUSE = Object.assign({ likes: 1500, comments: 1700, shares: 1800 }, USER_CONFIG.PAUSE);
   const STABLE_LIMIT = 10, EMPTY_PASSES = 4;
 
   // ===== Politeness controls =====
-  const LIMITS = { MAX_ACTIONS_PER_MIN: 28, SOFT_ROW_CAP: 2000, MAX_RUN_MS: 8*60*1000 };
+  const LIMITS = Object.assign({ MAX_ACTIONS_PER_MIN: 28, SOFT_ROW_CAP: 2000, MAX_RUN_MS: 8*60*1000 }, USER_CONFIG.LIMITS);
   function jitter(ms, ratio=0.30){ const d=ms*ratio; return Math.max(0, Math.round(ms + (Math.random()*2-1)*d)); }
   async function yieldToBrowser(){ await new Promise(r=>requestAnimationFrame(r)); if('requestIdleCallback' in window){ await new Promise(r=>requestIdleCallback(r,{timeout:1200})); } }
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,42 @@
-PURGE UPDATES:
+# Facebook Web Scraper
+
+Utility script for collecting the people who have liked, commented on, or shared a Facebook post. The script runs directly in your browser and provides a panel for exporting results to CSV.
+
+## Usage
+
+1. Navigate to the Facebook post you want to analyze and open the list of reactions, comments, or shares.
+2. Open your browser's developer console (usually with <kbd>F12</kbd> or <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>I</kbd>).
+3. Paste the contents of [`Facebook Scraper.js`](Facebook%20Scraper.js) into the console and press <kbd>Enter</kbd>.
+4. Use the floating panel to collect data and download the CSV file.
+
+The latest version of the script can also be loaded from jsDelivr:
+
+```
+https://cdn.jsdelivr.net/gh/mattlavergne/Facebook-Web-Scraper@main/Facebook%20Scraper.js
+```
+
+## Configuration
+
+You can adjust timing and throttle limits without editing the script by defining a `FBP_CONFIG` object before running it:
+
+```html
+<script>
+window.FBP_CONFIG = {
+  PAUSE: { likes: 2000 },
+  LIMITS: { MAX_ACTIONS_PER_MIN: 20 }
+};
+</script>
+```
+
+Only the specified fields override the defaults.
+
+## Cache purge
+
+If you update the script and serve it via jsDelivr, you may need to purge the CDN cache:
+
+```
 https://purge.jsdelivr.net/gh/mattlavergne/Facebook-Web-Scraper@main/Facebook%20Scraper.js
+```
+
+Use responsibly and respect Facebook's terms of service.
+


### PR DESCRIPTION
## Summary
- allow overriding pause and throttle limits via global `FBP_CONFIG`
- document script usage, configuration, and cache purging

## Testing
- `node --check 'Facebook Scraper.js'`


------
https://chatgpt.com/codex/tasks/task_b_68adcf0961dc83299e44a8de0731d376