### PR TITLE
Make preview table resize with panel

### DIFF
--- a/Facebook Scraper.js
+++ b/Facebook Scraper.js
@@ -94,12 +94,15 @@
       #fbp-win .winbtn.close:hover{ background:#c42b1c; color:#fff; border-color:#7a1410 }
 
       /* Scrollable body */
-      #fbp-body{ flex:1; display:flex; flex-direction:column; gap:8px; overflow:auto; min-height:0; padding:6px; }
+      #fbp-body{ flex:1; display:flex; flex-direction:column; gap:8px; overflow:hidden; min-height:0; padding:6px; }
       #fbp-panel table { width:100% }
       #fbp-panel table tr:hover td { background:#303031 }
       #fbp-prog { transition: width .2s ease }
 
-      #fbp-prev{ border:1px solid #3a3b3c;border-radius:8px; }
+      /* Preview flexes with available space */
+      #fbp-preview-wrap{ flex:1 1 auto; display:flex; flex-direction:column; min-height:0; max-height:1000px; transition:max-height .2s ease, opacity .2s ease; overflow:hidden; }
+      #fbp-preview-wrap.hidden{ max-height:0; opacity:0; }
+      #fbp-prev{ flex:1 1 auto; overflow:auto; border:1px solid #3a3b3c; border-radius:8px; }
 
       /* Footer: flex item normally, absolute when minimized */
       .fbp-bar{ display:flex; flex-wrap:wrap; align-items:center; gap:8px; margin-top:8px;
@@ -176,7 +179,7 @@
         '<div style="font-size:11px;opacity:.8;margin:8px 0 6px;display:flex;justify-content:space-between;align-items:center">' +
           '<span title="Preview of first 50">👁️ First 50</span>' +
         '</div>' +
-        '<div id="fbp-prev" style="height:80px;overflow:hidden;border:1px solid #293042;border-radius:8px"></div>' +
+        '<div id="fbp-prev"></div>' +
       '</div>' +
     '</div>' +
     '<div id="fbp-bar" class="fbp-bar">' +
@@ -342,7 +345,9 @@
   setActiveMode('likes');
 
   // ===== refs & utils (single, non-duplicated)
+  const prevWrap  = ui.querySelector('#fbp-preview-wrap');
   const prevBox   = ui.querySelector('#fbp-prev');
+  const bar       = ui.querySelector('#fbp-bar');
   const likeC     = ui.querySelector('#fbp-likec');
   const commentC  = ui.querySelector('#fbp-commentc');
   const shareC    = ui.querySelector('#fbp-sharec');
@@ -537,8 +542,13 @@
   // ===== PREVIEW
   function renderPreview(){
     const rows = Array.from(store.values());
-    if(rows.length === 0){ prevBox.style.height='80px'; prevBox.style.overflowY='hidden'; }
-    else { prevBox.style.height='clamp(120px,18vh,230px)'; prevBox.style.overflowY='auto'; }
+    if(rows.length === 0){
+      prevBox.innerHTML = '';
+      prevWrap.classList.add('hidden');
+      updateStats();
+      return;
+    }
+    prevWrap.classList.remove('hidden');
 
     let head =
       '<table style="width:100%;border-collapse:collapse;table-layout:fixed;font-size:11px">' +
@@ -567,8 +577,20 @@
       '</tr>';
     }
     prevBox.innerHTML = head + body + '</tbody></table>';
+    adjustPreviewVisibility();
     updateStats();
   }
+
+  function adjustPreviewVisibility(){
+    if(!prevBox.innerHTML){ prevWrap.classList.add('hidden'); return; }
+    const avail = bar.getBoundingClientRect().top - prevWrap.getBoundingClientRect().top - 8;
+    if(avail < 40) prevWrap.classList.add('hidden');
+    else prevWrap.classList.remove('hidden');
+  }
+  const _prevRO = new ResizeObserver(()=>adjustPreviewVisibility());
+  _prevRO.observe(ui);
+  adjustPreviewVisibility();
+
   function escapeHTML(s){ return (s||'').replace(/[&<>"]/g, m=>({ '&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;' }[m])); }
   function shorten(s,n){ s=String(s||''); return s.length>n ? (s.slice(0,n-1)+'…') : s; }
 

--- a/README.md
+++ b/README.md
@@ -9,10 +9,20 @@ Utility script for collecting the people who have liked, commented on, or shared
 3. Paste the contents of [`Facebook Scraper.js`](Facebook%20Scraper.js) into the console and press <kbd>Enter</kbd>.
 4. Use the floating panel to collect data and download the CSV file.
 
-The latest version of the script can also be loaded from jsDelivr:
+The latest version of the script can also be loaded directly from GitHub:
 
 ```
-https://cdn.jsdelivr.net/gh/mattlavergne/Facebook-Web-Scraper@main/Facebook%20Scraper.js
+https://raw.githubusercontent.com/mattlavergne/Facebook-Web-Scraper/main/Facebook%20Scraper.js
+```
+
+To use the scraper as a Tampermonkey userscript, reference the same URL in an `@require` directive:
+
+```
+// ==UserScript==
+// @name         FB Web Scraper Loader
+// @match        *://www.facebook.com/*
+// @require      https://raw.githubusercontent.com/mattlavergne/Facebook-Web-Scraper/main/Facebook%20Scraper.js
+// ==/UserScript==
 ```
 
 ## Configuration
@@ -29,14 +39,6 @@ window.FBP_CONFIG = {
 ```
 
 Only the specified fields override the defaults.
-
-## Cache purge
-
-If you update the script and serve it via jsDelivr, you may need to purge the CDN cache:
-
-```
-https://purge.jsdelivr.net/gh/mattlavergne/Facebook-Web-Scraper@main/Facebook%20Scraper.js
-```
 
 Use responsibly and respect Facebook's terms of service.
 


### PR DESCRIPTION
## Summary
- Flex the preview table so more rows show as the panel grows
- Fade out and collapse the preview when space runs out or it's empty
- Document how to load the script via a raw GitHub `@require` URL in Tampermonkey

## Testing
- `node --check 'Facebook Scraper.js'`


------
https://chatgpt.com/codex/tasks/task_b_68add323815883299968f21dc264c016